### PR TITLE
Ensure unique ticker-date entries in simulated trades

### DIFF
--- a/assistant_vocal.py
+++ b/assistant_vocal.py
@@ -106,15 +106,20 @@ def _simulate_buy(ticker: str) -> str:
     try:
         conn = sqlite3.connect(DB_PATH)
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS trades_simules (id INTEGER PRIMARY KEY AUTOINCREMENT, ticker TEXT, date TEXT)"
+            "CREATE TABLE IF NOT EXISTS trades_simules (id INTEGER PRIMARY KEY AUTOINCREMENT, ticker TEXT NOT NULL, date TEXT NOT NULL, UNIQUE(ticker, date))"
         )
-        conn.execute(
-            "INSERT INTO trades_simules (ticker, date) VALUES (?, ?)",
-            (ticker, datetime.utcnow().isoformat()),
-        )
-        conn.commit()
-        conn.close()
-        return f"Ordre simulé pour {ticker}."
+        try:
+            conn.execute(
+                "INSERT INTO trades_simules (ticker, date) VALUES (?, ?)",
+                (ticker, datetime.utcnow().isoformat()),
+            )
+            conn.commit()
+            msg = f"Ordre simulé pour {ticker}."
+        except sqlite3.IntegrityError:
+            msg = f"Ordre déjà enregistré pour {ticker}."
+        finally:
+            conn.close()
+        return msg
     except Exception as exc:
         return f"Erreur: {exc}"
 

--- a/core/models.py
+++ b/core/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, UniqueConstraint
 from .db import Base
 
 
@@ -38,9 +38,10 @@ class IntradaySmart(Base):
 
 class TradeSimule(Base):
     __tablename__ = "trades_simules"
+    __table_args__ = (UniqueConstraint("ticker", "date"),)
 
     id = Column(Integer, primary_key=True)
-    ticker = Column(String)
+    ticker = Column(String, nullable=False)
     prix_achat = Column(Float)
     quantite = Column(Integer)
     frais = Column(Float)
@@ -48,7 +49,7 @@ class TradeSimule(Base):
     sl = Column(Float)
     tp = Column(Float)
     exit_price = Column(Float)
-    date = Column(DateTime, default=datetime.utcnow)
+    date = Column(DateTime, nullable=False, default=datetime.utcnow)
     provenance = Column(String)
     note = Column(String)
 

--- a/db/utils.py
+++ b/db/utils.py
@@ -38,7 +38,7 @@ def ensure_schema(db_path: str = DB_PATH) -> None:
                 """
                 CREATE TABLE trades_simules (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    ticker TEXT,
+                    ticker TEXT NOT NULL,
                     prix_achat REAL,
                     quantite INTEGER,
                     frais REAL,
@@ -46,9 +46,10 @@ def ensure_schema(db_path: str = DB_PATH) -> None:
                     sl REAL,
                     tp REAL,
                     exit_price REAL,
-                    date DATETIME,
+                    date DATETIME NOT NULL,
                     provenance TEXT,
-                    note TEXT
+                    note TEXT,
+                    UNIQUE(ticker, date)
                 )
                 """
             )
@@ -73,6 +74,12 @@ def ensure_schema(db_path: str = DB_PATH) -> None:
                     conn.execute(
                         f"ALTER TABLE trades_simules ADD COLUMN {col} {typ};"
                     )
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_simules_ticker_date
+            ON trades_simules(ticker, date)
+            """
+        )
         # Ensure progression_ia table
         conn.execute(
             """

--- a/migration/versions/003_create_trades_simules.py
+++ b/migration/versions/003_create_trades_simules.py
@@ -11,7 +11,7 @@ def upgrade():
     op.create_table(
         'trades_simules',
         sa.Column('id', sa.Integer, primary_key=True),
-        sa.Column('ticker', sa.String),
+        sa.Column('ticker', sa.String, nullable=False),
         sa.Column('prix_achat', sa.Float),
         sa.Column('quantite', sa.Integer),
         sa.Column('frais', sa.Float),
@@ -19,9 +19,10 @@ def upgrade():
         sa.Column('sl', sa.Float),
         sa.Column('tp', sa.Float),
         sa.Column('exit_price', sa.Float),
-        sa.Column('date', sa.DateTime, default=sa.func.now()),
+        sa.Column('date', sa.DateTime, nullable=False, default=sa.func.now()),
         sa.Column('provenance', sa.String),
         sa.Column('note', sa.String),
+        sa.UniqueConstraint('ticker', 'date', name='uix_trades_simules_ticker_date'),
     )
 
 def downgrade():


### PR DESCRIPTION
## Summary
- enforce NOT NULL and unique constraints on `ticker` and `date` for `trades_simules`
- gracefully handle duplicate simulated trade inserts
- add unique index maintenance and ORM model updates

## Testing
- `pytest tests/test_assistant_vocal.py tests/test_learn_from_trades.py tests/test_migrations.py tests/test_db_trades.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac57ab27388330ac1a832c1c37f626