### PR TITLE
Add ticker indexes

### DIFF
--- a/db/init_sqlite.py
+++ b/db/init_sqlite.py
@@ -2,5 +2,12 @@ import sqlite3
 
 def init(conn: sqlite3.Connection):
     conn.execute("PRAGMA journal_mode=WAL;")
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_ticks_symbol_ts ON intraday_smart(symbol, ts);")
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_scores_symbol_date ON scores(symbol, date);")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_intraday_smart_ticker ON intraday_smart(ticker);"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_intraday_smart_ticker_created_at ON intraday_smart(ticker, created_at);"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scores_symbol_date ON scores(symbol, date);"
+    )

--- a/migration/versions/004_add_intraday_smart_indexes.py
+++ b/migration/versions/004_add_intraday_smart_indexes.py
@@ -1,0 +1,23 @@
+"""add indexes to intraday_smart"""
+from alembic import op
+
+revision = '004'
+down_revision = '003'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_index(
+        'idx_intraday_smart_ticker',
+        'intraday_smart',
+        ['ticker'],
+    )
+    op.create_index(
+        'idx_intraday_smart_ticker_created_at',
+        'intraday_smart',
+        ['ticker', 'created_at'],
+    )
+ 
+def downgrade():
+    op.drop_index('idx_intraday_smart_ticker', table_name='intraday_smart')
+    op.drop_index('idx_intraday_smart_ticker_created_at', table_name='intraday_smart')

--- a/schema_update.sql
+++ b/schema_update.sql
@@ -11,3 +11,7 @@ ALTER TABLE trades ADD COLUMN source_data TEXT;
 ALTER TABLE watchlist ADD COLUMN pump_pct_60s REAL;
 ALTER TABLE watchlist ADD COLUMN ema_diff REAL;
 ALTER TABLE watchlist ADD COLUMN rsi REAL;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_intraday_smart_ticker ON intraday_smart(ticker);
+CREATE INDEX IF NOT EXISTS idx_intraday_smart_ticker_created_at ON intraday_smart(ticker, created_at);


### PR DESCRIPTION
## Summary
- add `ticker` and `(ticker, created_at)` indexes to `intraday_smart`
- document new indexes in schema update script

## Testing
- `pytest`
- `pre-commit run --files db/init_sqlite.py schema_update.sql migration/versions/004_add_intraday_smart_indexes.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac57ad53208330a0afb03cd1d1a69d